### PR TITLE
Update model to mistral:7b

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ to run:
 
 If you want to use a native Ollama installation instead of a Dockerised version, do the following:
 
-- Install `ollama` (e.g. with `brew install ollama`), run it and install your desired models.
--
+- Install `ollama` (e.g. with `brew install ollama`), and run it in the background:
 
 ```shell
 $ ollama serve &
@@ -32,7 +31,7 @@ $ ollama serve &
 
 ```shell
 $ ollama pull llama3:8b &
-$ ollama pull yarn-mistral:7b-128k &
+$ ollama pull mistral:7b &
 ```
 
 Now run the `frontend` and `backend` with `docker`:

--- a/backend/ollama_query.py
+++ b/backend/ollama_query.py
@@ -20,7 +20,7 @@ class OllamaQuery:
         # Load the model
         context_length = len(context.split())
         if context_length > 8000:
-            model = os.environ.get("OLLAMA_MODEL", "yarn-mistral:7b-128k")
+            model = os.environ.get("OLLAMA_MODEL", "mistral:7b")
         else:
             model = os.environ.get("OLLAMA_MODEL", "llama3:8b")
 

--- a/docker/backend.Dockerfile
+++ b/docker/backend.Dockerfile
@@ -25,9 +25,6 @@ RUN apk add --no-cache libffi
 COPY --from=builder /app/venv /app/venv
 COPY backend backend
 
-# Which model to use
-ENV OLLAMA_MODEL "llama3:8b"
-
 EXPOSE 5000
 
 CMD ["venv/bin/python", "-m", "flask", "--app", "backend/app", "run", "--host", "0.0.0.0", "--debug"]

--- a/docker/docker-compose-native-ollama.yaml
+++ b/docker/docker-compose-native-ollama.yaml
@@ -7,7 +7,6 @@ services:
       dockerfile: docker/backend.Dockerfile
     environment:
       OLLAMA_HOST: "http://host.docker.internal"
-      OLLAMA_MODEL: "llama3:8b"
       OLLAMA_PORT: "11434"
     ports:
       - "127.0.0.1:3000:5000"


### PR DESCRIPTION
- Use `mistral:7b` instead of `yarn-mistral:7b-128k` as it produces better output
